### PR TITLE
Punctuation changes in title

### DIFF
--- a/Display/title.drl
+++ b/Display/title.drl
@@ -9,7 +9,7 @@ rule "Primo VE - Title"
       remove string (TEMP"1","<<")
       remove string (TEMP"1",">>")
     set TEMP"2" to MARC."245" subfields "c"
-      concatenate with delimiter (TEMP"1",TEMP"2","")
+      concatenate with delimiter (TEMP"1",TEMP"2"," ")
     create pnx."display"."title" with TEMP"1"
 end
 

--- a/Display/title.drl
+++ b/Display/title.drl
@@ -8,9 +8,7 @@ rule "Primo VE - Title"
     set TEMP"1" to prima display title
       remove string (TEMP"1","<<")
       remove string (TEMP"1",">>")
-      remove substring using regex (TEMP"1","(,|/|:|;|=)+$")
     set TEMP"2" to MARC."245" subfields "c"
-      remove substring using regex (TEMP"2","(,|/|:|;|=)+$")
       concatenate with delimiter (TEMP"1",TEMP"2","")
     create pnx."display"."title" with TEMP"1"
 end
@@ -23,6 +21,5 @@ rule "Primo VE - Title1"
     set TEMP"1" to prima display title
       remove string (TEMP"1","<<")
       remove string (TEMP"1",">>")
-      remove substring using regex (TEMP"1","(,|/|:|;|=)+$")
     create pnx."display"."title" with TEMP"1"
 end


### PR DESCRIPTION
Added subfield $c to display following the rest of a bib Title.

Titles with subfield $c will no longer remove trailing commas (,), forward slashes (/), colons (:), semicolons (;), or equal signs (=).