### PR TITLE
Restrict Ownership History

### DIFF
--- a/Display/local_field_13.drl
+++ b/Display/local_field_13.drl
@@ -11,9 +11,10 @@ end
 
 rule "Primo VE - Lds13 561"
   when
-     MARC."561" has any "3,a,u,5" AND (
-        MARC."561".ind"1" equals " " OR
-        MARC."561".ind"1" equals "1")
+    MARC."561" has any "3,a,u,5" AND 
+    MARC."561"."5" match "CU-SB" AND (
+      MARC."561".ind"1" equals " " OR
+      MARC."561".ind"1" equals "1")
   then
-    create pnx."display"."lds13" with MARC "561" subfields "3,a,u,5"
+    create pnx."display"."lds13" with MARC "561" subfields "3,a,u"
 end

--- a/Search/local_field_13.drl
+++ b/Search/local_field_13.drl
@@ -11,9 +11,10 @@ end
 
 rule "Primo VE Marc - Lsr13 561"
   when
-     MARC."561" has any "3,a,u,5" AND (
-        MARC."561".ind"1" equals " " OR
-        MARC."561".ind"1" equals "1")
+    MARC."561" has any "3,a,u,5" AND
+    MARC."561"."5" match "CU-SB" AND (
+      MARC."561".ind"1" equals " " OR
+      MARC."561".ind"1" equals "1")
   then
-    create pnx."search"."lsr13" with MARC "561" subfields "3,a,u,5"
+    create pnx."search"."lsr13" with MARC "561" subfields "3,a,u"
 end


### PR DESCRIPTION
We only want this field to display or be searchable if 561 subfield $5 equals `CU-SB`.

Adopting the new search rules will require contacting Ex Libris for reindexing.